### PR TITLE
Move to Atlas, use .env variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,5 @@
     "node": "lts"
   },
   "homepage": "https://github.com/dpMelian/pokeapi-mern#readme",
-  "version": "0.7.0"
+  "version": "0.8.0"
 }

--- a/server/src/db/conn.js
+++ b/server/src/db/conn.js
@@ -1,11 +1,11 @@
 import mongoose from "mongoose"
-const database = "mongodb://127.0.0.1:27017/pokeapi-db"
+const uri = `mongodb+srv://${process.env.DB_USER}:${process.env.DB_PASSWORD}@${process.env.DB_URI}/?retryWrites=true&w=majority&appName=${process.env.DB_APP_NAME}`
 
 var _db
 
 export const connectToServer = () => {
   mongoose
-    .connect(database, {
+    .connect(uri, {
       useNewUrlParser: true,
       useUnifiedTopology: true,
     })


### PR DESCRIPTION
## Explanation of the change

Move to MongoDB Atlas cluster instead of using local database
